### PR TITLE
Correct manual change to nidigital metadata

### DIFF
--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2637,7 +2637,10 @@ class _SessionBase(object):
             site_numbers (list of int): The returned site numbers that correspond to data read from the digital pattern instrument using the specified repeated capabilities. If you do not want to use this parameter, pass VI_NULL.
 
             channel_indexes (list of int): The returned index of channels corresponding to data read from the digital pattern instrument using the specified repeated capabilities. If you do not want to use this parameter, pass VI_NULL.
-                Call get_channel_names to get the name of the channel associated with an index. Channel indexes are one-based.
+                Call GetChannelName to get the name of the channel associated with an index. Channel indexes are one-based.
+
+                Note:
+                One or more of the referenced methods are not in the Python API for this driver.
 
         '''
         pin_indexes, site_numbers, channel_indexes = self._library_interpreter.get_pin_results_pin_information(self._repeated_capability)

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -2325,7 +2325,7 @@ functions = {
             {
                 'direction': 'out',
                 'documentation': {
-                    'description': 'The returned index of channels corresponding to data read from the digital pattern instrument using the specified repeated capabilities. If you do not want to use this parameter, pass VI_NULL.\nCall niDigital_GetChannelNameFromString to get the name of the channel associated with an index. Channel indexes are one-based.\n'
+                    'description': 'The returned index of channels corresponding to data read from the digital pattern instrument using the specified repeated capabilities. If you do not want to use this parameter, pass VI_NULL.\nCall niDigital_GetChannelName to get the name of the channel associated with an index. Channel indexes are one-based.\n'
                 },
                 'name': 'channelIndexes',
                 'size': {


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~


~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

#1819 mistakenly tweaked our internal exported metadata.
This change regenerates the NI-Digital API using the latest internal metadata export.

The correction made as part of the other PR was well intentioned, but incorrect. An assumption was made that because we don't allow calls to GetChannelName, the documentation should be updated to mention GetChannelNameFromString, instead. This is incorrect.

GetChannelName is what's mentioned in the C Documentation for `GetPinResultsPinInformation` and the 1-based index comment does not apply for `GetChannelNameFromString`. Furthermore, we handle the 1-based index as part of the Fancy Function, before calling `get_channel_names` which shows that the 1-based comment is correct. The best thing to do here seems to be to keep the original C API documentation as it was, even though it mentions a function that we don't provide access to; it's documentation for an internal function, so it's fine.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

None
